### PR TITLE
[Parallel Router] Simplified the Heap Node Structure

### DIFF
--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1736,6 +1736,7 @@ struct t_rr_node_route_inf {
     float acc_cost;
     float path_cost;
     float backward_path_cost;
+    float R_upstream;
 
   public: //Accessors
     short occ() const { return occ_; }

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1736,7 +1736,13 @@ struct t_rr_node_route_inf {
     float acc_cost;
     float path_cost;
     float backward_path_cost;
-    float R_upstream;
+    float R_upstream; // TODO: Investigate the effect of adding the R_upstream field in
+                      //       this struct. It is put in for the fine-grained parallel
+                      //       router's benefits. It is increasing the working set, which
+                      //       can have some performance implications. This could affect
+                      //       the performance of the serial connection router, which will
+                      //       make the Hybrid Connection Router less efficient (but that
+                      //       needs to be investigated).
 
   public: //Accessors
     short occ() const { return occ_; }

--- a/vpr/src/route/multi_queue_priority_queue.cpp
+++ b/vpr/src/route/multi_queue_priority_queue.cpp
@@ -26,12 +26,14 @@ bool MultiQueuePriorityQueue::try_pop(pq_prio_t &prio, RRNodeId &node) {
     } else {
         pq_index_t node_id;
         std::tie(prio, node_id) = tmp.get();
+        static_assert(sizeof(RRNodeId) == sizeof(pq_index_t));
         node = RRNodeId(node_id);
         return true;
     }
 }
 
-inline pq_index_t cast_RRNodeId_to_pq_index_t(RRNodeId node) {
+static inline pq_index_t cast_RRNodeId_to_pq_index_t(RRNodeId node) {
+    static_assert(sizeof(RRNodeId) == sizeof(pq_index_t));
     return static_cast<pq_index_t>(std::size_t(node));
 }
 

--- a/vpr/src/route/multi_queue_priority_queue.cpp
+++ b/vpr/src/route/multi_queue_priority_queue.cpp
@@ -19,23 +19,23 @@ void MultiQueuePriorityQueue::init_heap(const DeviceGrid& grid) {
     // TODO: Reserve storage for MQ_IO
 }
 
-bool MultiQueuePriorityQueue::try_pop(pq_node_t &pq_top) {
+bool MultiQueuePriorityQueue::try_pop(pq_prio_t &prio, pq_index_t &node) {
     auto tmp = pq_->tryPop();
     if (!tmp) {
         return false;
     } else {
-        pq_top = std::get<1>(tmp.get());
+        std::tie(prio, node) = tmp.get();
         return true;
     }
 }
 
-void MultiQueuePriorityQueue::add_to_heap(const pq_node_t& hptr) {
-    pq_->push({hptr.cost, hptr});
+void MultiQueuePriorityQueue::add_to_heap(const pq_prio_t& prio, const pq_index_t& node) {
+    pq_->push({prio, node});
 }
 
-void MultiQueuePriorityQueue::push_back(const pq_node_t& hptr) {
-    // push_batch_buffer_.push_back({hptr.cost, hptr});
-    pq_->push({hptr.cost, hptr});
+void MultiQueuePriorityQueue::push_back(const pq_prio_t& prio, const pq_index_t& node) {
+    // push_batch_buffer_.push_back({hptr.cost, hptr}); // TODO: heap memory reservation
+    pq_->push({prio, node});
 }
 
 bool MultiQueuePriorityQueue::is_empty_heap() const {

--- a/vpr/src/route/multi_queue_priority_queue.cpp
+++ b/vpr/src/route/multi_queue_priority_queue.cpp
@@ -19,23 +19,29 @@ void MultiQueuePriorityQueue::init_heap(const DeviceGrid& grid) {
     // TODO: Reserve storage for MQ_IO
 }
 
-bool MultiQueuePriorityQueue::try_pop(pq_prio_t &prio, pq_index_t &node) {
+bool MultiQueuePriorityQueue::try_pop(pq_prio_t &prio, RRNodeId &node) {
     auto tmp = pq_->tryPop();
     if (!tmp) {
         return false;
     } else {
-        std::tie(prio, node) = tmp.get();
+        pq_index_t node_id;
+        std::tie(prio, node_id) = tmp.get();
+        node = RRNodeId(node_id);
         return true;
     }
 }
 
-void MultiQueuePriorityQueue::add_to_heap(const pq_prio_t& prio, const pq_index_t& node) {
-    pq_->push({prio, node});
+inline pq_index_t cast_RRNodeId_to_pq_index_t(RRNodeId node) {
+    return static_cast<pq_index_t>(std::size_t(node));
 }
 
-void MultiQueuePriorityQueue::push_back(const pq_prio_t& prio, const pq_index_t& node) {
+void MultiQueuePriorityQueue::add_to_heap(const pq_prio_t& prio, const RRNodeId& node) {
+    pq_->push({prio, cast_RRNodeId_to_pq_index_t(node)});
+}
+
+void MultiQueuePriorityQueue::push_back(const pq_prio_t& prio, const RRNodeId& node) {
     // push_batch_buffer_.push_back({hptr.cost, hptr}); // TODO: heap memory reservation
-    pq_->push({prio, node});
+    pq_->push({prio, cast_RRNodeId_to_pq_index_t(node)});
 }
 
 bool MultiQueuePriorityQueue::is_empty_heap() const {

--- a/vpr/src/route/multi_queue_priority_queue.h
+++ b/vpr/src/route/multi_queue_priority_queue.h
@@ -7,14 +7,6 @@
 
 #include "rr_graph_fwd.h"
 
-struct node_t {
-    float total_cost;
-    float backward_path_cost;
-    float R_upstream;
-    RREdgeId prev_edge;
-};
-
-
 using pq_prio_t = float;
 using pq_index_t = uint32_t;
 

--- a/vpr/src/route/multi_queue_priority_queue.h
+++ b/vpr/src/route/multi_queue_priority_queue.h
@@ -30,24 +30,28 @@ struct pq_node_t {
     }
 };
 
+
+using pq_prio_t = float;
+using pq_index_t = RRNodeId;
+
 class MultiQueuePriorityQueue {
   public:
-    using pq_pair_t = std::tuple<float /*priority*/, pq_node_t>;
+    using pq_pair_t = std::tuple<pq_prio_t /*priority*/, pq_index_t>;
     struct pq_compare {
         bool operator()(const pq_pair_t& u, const pq_pair_t& v) {
             return std::get<0>(u) > std::get<0>(v);
         }
     };
-    using MQ_IO = MultiQueueIO<pq_compare, float, pq_node_t>;
+    using MQ_IO = MultiQueueIO<pq_compare, pq_prio_t, pq_index_t>;
 
     MultiQueuePriorityQueue();
     MultiQueuePriorityQueue(size_t num_threads, size_t num_queues);
     ~MultiQueuePriorityQueue();
 
     void init_heap(const DeviceGrid& grid);
-    bool try_pop(pq_node_t &pq_top);
-    void add_to_heap(const pq_node_t& hptr);
-    void push_back(const pq_node_t& hptr);
+    bool try_pop(pq_prio_t &prio, pq_index_t &node);
+    void add_to_heap(const pq_prio_t& prio, const pq_index_t& node);
+    void push_back(const pq_prio_t& prio, const pq_index_t& node);
     bool is_empty_heap() const;
     bool is_valid() const;
     void empty_heap();
@@ -58,7 +62,7 @@ class MultiQueuePriorityQueue {
 
   private:
     MQ_IO* pq_;
-    // std::vector<pq_node_t> push_batch_buffer_;
+    // std::vector<pq_node_t> push_batch_buffer_; // TODO: heap memory reservation
 };
 
 #endif /* _MULTI_QUEUE_PRIORITY_QUEUE_H */

--- a/vpr/src/route/multi_queue_priority_queue.h
+++ b/vpr/src/route/multi_queue_priority_queue.h
@@ -7,32 +7,16 @@
 
 #include "rr_graph_fwd.h"
 
-struct pq_node_t {
-    float cost = 0.;
-    float backward_path_cost = 0.;
-    float R_upstream = 0.;
-
-    RRNodeId index = RRNodeId::INVALID(); // TODO: to be optimized
-
-    uint32_t prev_edge_id;
-
-    pq_node_t() {}
-    pq_node_t(size_t dont_care) { (void)dont_care; } // for MQ compatibility
-
-    constexpr RREdgeId prev_edge() const {
-        static_assert(sizeof(uint32_t) == sizeof(RREdgeId));
-        return RREdgeId(prev_edge_id);
-    }
-
-    inline void set_prev_edge(RREdgeId edge) {
-        static_assert(sizeof(uint32_t) == sizeof(RREdgeId));
-        prev_edge_id = size_t(edge);
-    }
+struct node_t {
+    float total_cost;
+    float backward_path_cost;
+    float R_upstream;
+    RREdgeId prev_edge;
 };
 
 
 using pq_prio_t = float;
-using pq_index_t = RRNodeId;
+using pq_index_t = size_t;
 
 class MultiQueuePriorityQueue {
   public:

--- a/vpr/src/route/multi_queue_priority_queue.h
+++ b/vpr/src/route/multi_queue_priority_queue.h
@@ -16,7 +16,7 @@ struct node_t {
 
 
 using pq_prio_t = float;
-using pq_index_t = size_t;
+using pq_index_t = uint32_t;
 
 class MultiQueuePriorityQueue {
   public:
@@ -33,9 +33,9 @@ class MultiQueuePriorityQueue {
     ~MultiQueuePriorityQueue();
 
     void init_heap(const DeviceGrid& grid);
-    bool try_pop(pq_prio_t &prio, pq_index_t &node);
-    void add_to_heap(const pq_prio_t& prio, const pq_index_t& node);
-    void push_back(const pq_prio_t& prio, const pq_index_t& node);
+    bool try_pop(pq_prio_t &prio, RRNodeId &node);
+    void add_to_heap(const pq_prio_t& prio, const RRNodeId& node);
+    void push_back(const pq_prio_t& prio, const RRNodeId& node);
     bool is_empty_heap() const;
     bool is_valid() const;
     void empty_heap();

--- a/vpr/src/route/parallel_connection_router.cpp
+++ b/vpr/src/route/parallel_connection_router.cpp
@@ -316,8 +316,6 @@ static inline bool should_not_explore_neighbors(RRNodeId inode,
                                 vtr::vector<RRNodeId, t_rr_node_route_inf>& rr_node_route_inf_,
                                 const t_conn_cost_params& params) {
 #ifdef IS_DETERMINISTIC
-    (void)new_back_cost;
-    (void)target_node;
     // For deterministic pruning, cannot enforce anything on the total cost since
     // traversal order is not gaurenteed. However, since total cost is used as a
     // "key" to signify that this node is the last node that was pushed, we can
@@ -332,7 +330,6 @@ static inline bool should_not_explore_neighbors(RRNodeId inode,
     // neighbors which is not good. This is done before obtaining the lock to
     // prevent lock contention where possible.
     if (inode != target_node) {
-        float new_back_cost = rr_node_route_inf_[inode].backward_path_cost;
         float best_back_cost_to_target = rr_node_route_inf_[target_node].backward_path_cost;
         if (deterministic_post_target_prune_node(new_total_cost, new_back_cost, best_back_cost_to_target, params))
             return true;
@@ -406,7 +403,8 @@ void ParallelConnectionRouter::timing_driven_route_connection_from_heap_thread_f
         //                     cheapest->index,
         //                     rr_graph_);
 
-        // Pruning
+        // Should we explore the neighbors of this node?
+
         if (inode == sink_node) {
             continue;
         }

--- a/vpr/src/route/parallel_connection_router.h
+++ b/vpr/src/route/parallel_connection_router.h
@@ -318,7 +318,8 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
         pq_node_t* current,
         const t_conn_cost_params& cost_params,
         const t_bb& bounding_box,
-        RRNodeId target_node);
+        RRNodeId target_node,
+        size_t thread_idx);
 
     // Conditionally adds to_node to the router heap (via path from from_node
     // via from_edge).
@@ -333,7 +334,8 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
         const t_conn_cost_params& cost_params,
         const t_bb& bounding_box,
         RRNodeId target_node,
-        const t_bb& target_bb);
+        const t_bb& target_bb,
+        size_t thread_idx);
 
     // Add to_node to the heap, and also add any nodes which are connected by
     // non-configurable edges
@@ -343,7 +345,8 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
         RRNodeId from_node,
         RRNodeId to_node,
         RREdgeId from_edge,
-        RRNodeId target_node);
+        RRNodeId target_node,
+        size_t thread_idx);
 
     // Calculates the cost of reaching to_node
     void evaluate_timing_driven_node_costs(

--- a/vpr/src/route/parallel_connection_router.h
+++ b/vpr/src/route/parallel_connection_router.h
@@ -254,17 +254,17 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
     }
 
     // Update the route path to the node pointed to by cheapest.
-    inline void update_cheapest(pq_node_t* cheapest, size_t thread_idx) {
-        update_cheapest(cheapest, &rr_node_route_inf_[cheapest->index], thread_idx);
+    inline void update_cheapest(const node_t& cheapest, RRNodeId inode, size_t thread_idx) {
+        update_cheapest(cheapest, inode, &rr_node_route_inf_[inode], thread_idx);
     }
 
-    inline void update_cheapest(pq_node_t* cheapest, t_rr_node_route_inf* route_inf, size_t thread_idx) {
+    inline void update_cheapest(const node_t& cheapest, RRNodeId inode, t_rr_node_route_inf* route_inf, size_t thread_idx) {
         //Record final link to target
-        add_to_mod_list(cheapest->index, thread_idx);
+        add_to_mod_list(inode, thread_idx);
 
-        route_inf->prev_edge = cheapest->prev_edge();
-        route_inf->path_cost = cheapest->cost;
-        route_inf->backward_path_cost = cheapest->backward_path_cost;
+        route_inf->prev_edge = cheapest.prev_edge;
+        route_inf->path_cost = cheapest.total_cost;
+        route_inf->backward_path_cost = cheapest.backward_path_cost;
     }
 
     inline void obtainSpinLock(RRNodeId inode) {
@@ -315,7 +315,8 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
 
     // Expand each neighbor of the current node.
     void timing_driven_expand_neighbours(
-        pq_node_t* current,
+        const node_t& current,
+        RRNodeId from_node,
         const t_conn_cost_params& cost_params,
         const t_bb& bounding_box,
         RRNodeId target_node,
@@ -327,7 +328,7 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
     // RR nodes outside bounding box specified in bounding_box are not added
     // to the heap.
     void timing_driven_expand_neighbour(
-        pq_node_t* current,
+        const node_t& current,
         RRNodeId from_node,
         RREdgeId from_edge,
         RRNodeId to_node,
@@ -341,7 +342,7 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
     // non-configurable edges
     void timing_driven_add_to_heap(
         const t_conn_cost_params& cost_params,
-        const pq_node_t* current,
+        const node_t& current,
         RRNodeId from_node,
         RRNodeId to_node,
         RREdgeId from_edge,
@@ -350,7 +351,7 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
 
     // Calculates the cost of reaching to_node
     void evaluate_timing_driven_node_costs(
-        pq_node_t* to,
+        node_t* to,
         const t_conn_cost_params& cost_params,
         RRNodeId from_node,
         RRNodeId to_node,

--- a/vpr/src/route/parallel_connection_router.h
+++ b/vpr/src/route/parallel_connection_router.h
@@ -72,6 +72,15 @@ public:
     }
 };
 
+// `node_t` is a simplified version of `t_heap`, and is used as a bundle of node
+// information in the functions inside the routing loop.
+struct node_t {
+    float total_cost;
+    float backward_path_cost;
+    float R_upstream;
+    RREdgeId prev_edge;
+};
+
 class barrier_spin_t {
     size_t num_threads_ = 1;
     std::atomic<size_t> count_ = 0;

--- a/vpr/src/route/parallel_connection_router.h
+++ b/vpr/src/route/parallel_connection_router.h
@@ -140,6 +140,7 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
         , locks_(rr_node_route_inf.size())
         , router_debug_(false) {
         heap_.init_heap(grid);
+        rr_node_R_upstream_.resize(rr_node_route_inf.size(), 0.);
         only_opin_inter_layer = (grid.get_num_layers() > 1) && inter_layer_connections_limited_to_opin(*rr_graph);
         std::cout << "#T=" << mq_num_threads << " #Q=" << mq_num_queues << std::endl << std::flush;
         sub_threads_.resize(mq_num_threads-1);
@@ -388,6 +389,7 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
     const vtr::vector<ParentNetId, std::vector<std::vector<int>>>& net_terminal_groups;
     const vtr::vector<ParentNetId, std::vector<int>>& net_terminal_group_num;
     vtr::vector<RRNodeId, t_rr_node_route_inf>& rr_node_route_inf_;
+    vtr::vector<RRNodeId, float> rr_node_R_upstream_;
     bool is_flat_;
     std::vector<std::vector<RRNodeId>> modified_rr_node_inf_;
     RouterStats* router_stats_;

--- a/vpr/src/route/parallel_connection_router.h
+++ b/vpr/src/route/parallel_connection_router.h
@@ -140,7 +140,6 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
         , locks_(rr_node_route_inf.size())
         , router_debug_(false) {
         heap_.init_heap(grid);
-        rr_node_R_upstream_.resize(rr_node_route_inf.size(), 0.);
         only_opin_inter_layer = (grid.get_num_layers() > 1) && inter_layer_connections_limited_to_opin(*rr_graph);
         std::cout << "#T=" << mq_num_threads << " #Q=" << mq_num_queues << std::endl << std::flush;
         sub_threads_.resize(mq_num_threads-1);
@@ -393,7 +392,6 @@ class ParallelConnectionRouter : public ConnectionRouterInterface {
     const vtr::vector<ParentNetId, std::vector<std::vector<int>>>& net_terminal_groups;
     const vtr::vector<ParentNetId, std::vector<int>>& net_terminal_group_num;
     vtr::vector<RRNodeId, t_rr_node_route_inf>& rr_node_route_inf_;
-    vtr::vector<RRNodeId, float> rr_node_R_upstream_;
     bool is_flat_;
     std::vector<std::vector<RRNodeId>> modified_rr_node_inf_;
     RouterStats* router_stats_;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR is for simplifying the heap node structure used in the Multi-Queue parallel connection router implementation. This requires algorithm changes such that the global best costs are updated right before pushing a neighbor, and the pruning strategy after a node pops should also be changed to drop the stale nodes.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Cache-friendly heap; Reducing the huge copy and constructor overhead when pushing/popping nodes to/from the heap.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has passed MCNC benchmark and strong regression tests (only 2 QoR failure and 1 run failure, using 4 threads and 16 queues) so far. More benchmarks and tests will be done.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (change which adds functionality)

Note: more details can be found in the git commit messages.