### PR TITLE
Added Customized Heap and Occupancy Profiling for MQ

### DIFF
--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -410,6 +410,7 @@ static void SetupRoutingArch(const t_arch& Arch,
 static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts) {
     RouterOpts->do_check_rr_graph = Options.check_rr_graph;
     RouterOpts->astar_fac = Options.astar_fac;
+    RouterOpts->astar_offset = Options.astar_offset;
     RouterOpts->router_profiler_astar_fac = Options.router_profiler_astar_fac;
     RouterOpts->post_target_prune_fac = Options.post_target_prune_fac;
     RouterOpts->post_target_prune_offset = Options.post_target_prune_offset;

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -414,6 +414,10 @@ static void SetupRouterOpts(const t_options& Options, t_router_opts* RouterOpts)
     RouterOpts->router_profiler_astar_fac = Options.router_profiler_astar_fac;
     RouterOpts->post_target_prune_fac = Options.post_target_prune_fac;
     RouterOpts->post_target_prune_offset = Options.post_target_prune_offset;
+    RouterOpts->multi_queue_num_threads = Options.multi_queue_num_threads;
+    RouterOpts->multi_queue_num_queues = Options.multi_queue_num_queues;
+    RouterOpts->multi_queue_direct_draining = Options.multi_queue_direct_draining;
+    RouterOpts->thread_affinity = Options.thread_affinity;
     RouterOpts->bb_factor = Options.bb_factor;
     RouterOpts->criticality_exp = Options.criticality_exp;
     RouterOpts->max_criticality = Options.max_criticality;

--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -338,6 +338,7 @@ static void ShowRouterOpts(const t_router_opts& RouterOpts) {
 
         if (TIMING_DRIVEN == RouterOpts.router_algorithm) {
             VTR_LOG("RouterOpts.astar_fac: %f\n", RouterOpts.astar_fac);
+            VTR_LOG("RouterOpts.astar_offset: %f\n", RouterOpts.astar_offset);
             VTR_LOG("RouterOpts.router_profiler_astar_fac: %f\n", RouterOpts.router_profiler_astar_fac);
             VTR_LOG("RouterOpts.criticality_exp: %f\n", RouterOpts.criticality_exp);
             VTR_LOG("RouterOpts.max_criticality: %f\n", RouterOpts.max_criticality);
@@ -482,6 +483,7 @@ static void ShowRouterOpts(const t_router_opts& RouterOpts) {
         VTR_LOG("RouterOpts.exit_after_first_routing_iteration: %s\n", RouterOpts.exit_after_first_routing_iteration ? "true" : "false");
         if (TIMING_DRIVEN == RouterOpts.router_algorithm) {
             VTR_LOG("RouterOpts.astar_fac: %f\n", RouterOpts.astar_fac);
+            VTR_LOG("RouterOpts.astar_offset: %f\n", RouterOpts.astar_offset);
             VTR_LOG("RouterOpts.router_profiler_astar_fac: %f\n", RouterOpts.router_profiler_astar_fac);
             VTR_LOG("RouterOpts.post_target_prune_fac: %f\n", RouterOpts.post_target_prune_fac);
             VTR_LOG("RouterOpts.post_target_prune_offset: %f\n", RouterOpts.post_target_prune_offset);

--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -257,6 +257,12 @@ static void ShowRouterOpts(const t_router_opts& RouterOpts) {
         VTR_LOG("false\n");
     }
 
+    auto transform_thread_affinity_list_to_str = [](const std::vector<int>& aff) {
+        std::string str = aff.size() ? std::to_string(aff.front()) : "off";
+        for (size_t i = 1; i < aff.size(); str += ',' + std::to_string(aff[i++])) ;
+        return str;
+    };
+
     if (DETAILED == RouterOpts.route_type) {
         VTR_LOG("RouterOpts.router_algorithm: ");
         switch (RouterOpts.router_algorithm) {
@@ -340,6 +346,12 @@ static void ShowRouterOpts(const t_router_opts& RouterOpts) {
             VTR_LOG("RouterOpts.astar_fac: %f\n", RouterOpts.astar_fac);
             VTR_LOG("RouterOpts.astar_offset: %f\n", RouterOpts.astar_offset);
             VTR_LOG("RouterOpts.router_profiler_astar_fac: %f\n", RouterOpts.router_profiler_astar_fac);
+            VTR_LOG("RouterOpts.post_target_prune_fac: %f\n", RouterOpts.post_target_prune_fac);
+            VTR_LOG("RouterOpts.post_target_prune_offset: %f\n", RouterOpts.post_target_prune_offset);
+            VTR_LOG("RouterOpts.multi_queue_num_threads: %d\n", RouterOpts.multi_queue_num_threads);
+            VTR_LOG("RouterOpts.multi_queue_num_queues: %d\n", RouterOpts.multi_queue_num_queues);
+            VTR_LOG("RouterOpts.multi_queue_direct_draining: %s\n", RouterOpts.multi_queue_direct_draining ? "true" : "false");
+            VTR_LOG("RouterOpts.thread_affinity: %s\n", transform_thread_affinity_list_to_str(RouterOpts.thread_affinity).c_str());
             VTR_LOG("RouterOpts.criticality_exp: %f\n", RouterOpts.criticality_exp);
             VTR_LOG("RouterOpts.max_criticality: %f\n", RouterOpts.max_criticality);
             VTR_LOG("RouterOpts.init_wirelength_abort_threshold: %f\n", RouterOpts.init_wirelength_abort_threshold);
@@ -487,6 +499,10 @@ static void ShowRouterOpts(const t_router_opts& RouterOpts) {
             VTR_LOG("RouterOpts.router_profiler_astar_fac: %f\n", RouterOpts.router_profiler_astar_fac);
             VTR_LOG("RouterOpts.post_target_prune_fac: %f\n", RouterOpts.post_target_prune_fac);
             VTR_LOG("RouterOpts.post_target_prune_offset: %f\n", RouterOpts.post_target_prune_offset);
+            VTR_LOG("RouterOpts.multi_queue_num_threads: %d\n", RouterOpts.multi_queue_num_threads);
+            VTR_LOG("RouterOpts.multi_queue_num_queues: %d\n", RouterOpts.multi_queue_num_queues);
+            VTR_LOG("RouterOpts.multi_queue_direct_draining: %s\n", RouterOpts.multi_queue_direct_draining ? "true" : "false");
+            VTR_LOG("RouterOpts.thread_affinity: %s\n", transform_thread_affinity_list_to_str(RouterOpts.thread_affinity).c_str());
             VTR_LOG("RouterOpts.criticality_exp: %f\n", RouterOpts.criticality_exp);
             VTR_LOG("RouterOpts.max_criticality: %f\n", RouterOpts.max_criticality);
             VTR_LOG("RouterOpts.init_wirelength_abort_threshold: %f\n", RouterOpts.init_wirelength_abort_threshold);

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -2477,6 +2477,14 @@ argparse::ArgumentParser create_arg_parser(std::string prog_name, t_options& arg
         .default_value("1.2")
         .show_in(argparse::ShowIn::HELP_ONLY);
 
+    route_timing_grp.add_argument(args.astar_offset, "--astar_offset")
+        .help(
+            "Controls the directedness of the timing-driven router's exploration."
+            " It is a subtractive adjustment to the lookahead heuristic."
+            " Values between 0 and 1e-9 are resonable; higher values may increase quality at the expense of run-time.")
+        .default_value("0.0")
+        .show_in(argparse::ShowIn::HELP_ONLY);
+
     route_timing_grp.add_argument(args.router_profiler_astar_fac, "--router_profiler_astar_fac")
         .help(
             "Controls the directedness of the timing-driven router's exploration"

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -205,6 +205,7 @@ struct t_options {
 
     /* Timing-driven router options only */
     argparse::ArgValue<float> astar_fac;
+    argparse::ArgValue<float> astar_offset;
     argparse::ArgValue<float> router_profiler_astar_fac;
     argparse::ArgValue<float> post_target_prune_fac;
     argparse::ArgValue<float> post_target_prune_offset;

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -209,6 +209,10 @@ struct t_options {
     argparse::ArgValue<float> router_profiler_astar_fac;
     argparse::ArgValue<float> post_target_prune_fac;
     argparse::ArgValue<float> post_target_prune_offset;
+    argparse::ArgValue<int> multi_queue_num_threads;
+    argparse::ArgValue<int> multi_queue_num_queues;
+    argparse::ArgValue<bool> multi_queue_direct_draining;
+    argparse::ArgValue<std::vector<int>> thread_affinity;
     argparse::ArgValue<float> max_criticality;
     argparse::ArgValue<float> criticality_exp;
     argparse::ArgValue<float> router_init_wirelength_abort_threshold;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1332,6 +1332,8 @@ struct t_placer_opts {
  *             an essentially breadth-first search, astar_fac = 1 is near   *
  *             the usual astar algorithm and astar_fac > 1 are more         *
  *             aggressive.                                                  *
+ * astar_offset: Offset that is subtracted from the lookahead (expected     *
+ *               future costs) in the timing-driven router.                 *
  * max_criticality: The maximum criticality factor (from 0 to 1) any sink   *
  *                  will ever have (i.e. clip criticality to this number).  *
  * criticality_exp: Set criticality to (path_length(sink) / longest_path) ^ *
@@ -1419,6 +1421,7 @@ struct t_router_opts {
     enum e_router_algorithm router_algorithm;
     enum e_base_cost_type base_cost_type;
     float astar_fac;
+    float astar_offset;
     float router_profiler_astar_fac;
     float post_target_prune_fac;
     float post_target_prune_offset;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1425,6 +1425,10 @@ struct t_router_opts {
     float router_profiler_astar_fac;
     float post_target_prune_fac;
     float post_target_prune_offset;
+    int multi_queue_num_threads;
+    int multi_queue_num_queues;
+    bool multi_queue_direct_draining;
+    std::vector<int> thread_affinity;
     float max_criticality;
     float criticality_exp;
     float init_wirelength_abort_threshold;

--- a/vpr/src/place/timing_place_lookup.cpp
+++ b/vpr/src/place/timing_place_lookup.cpp
@@ -1187,7 +1187,8 @@ void OverrideDelayModel::compute_override_delay_model(
     RouterDelayProfiler& route_profiler,
     const t_router_opts& router_opts) {
     t_router_opts router_opts2 = router_opts;
-    router_opts2.astar_fac = 0.;
+    router_opts2.astar_fac = 0.f;
+    router_opts2.astar_offset = 0.f;
 
     //Look at all the direct connections that exist, and add overrides to delay model
     auto& device_ctx = g_vpr_ctx.device();

--- a/vpr/src/route/SerialNetlistRouter.h
+++ b/vpr/src/route/SerialNetlistRouter.h
@@ -21,8 +21,8 @@ class SerialNetlistRouter : public NetlistRouter {
         const RoutingPredictor& routing_predictor,
         const vtr::vector<ParentNetId, std::vector<std::unordered_map<RRNodeId, int>>>& choking_spots,
         bool is_flat)
-        : _serial_router(_make_router(router_lookahead, is_flat, false))
-        , _parallel_router(_make_router(router_lookahead, is_flat, true))
+        : _serial_router(_make_router(router_lookahead, router_opts, is_flat, false))
+        , _parallel_router(_make_router(router_lookahead, router_opts, is_flat, true))
         , _net_list(net_list)
         , _router_opts(router_opts)
         , _connections_inf(connections_inf)
@@ -45,8 +45,10 @@ class SerialNetlistRouter : public NetlistRouter {
 
   private:
     bool should_use_parallel_connection_router(const ParentNetId &net_id, int itry, float pres_fac, float worst_neg_slack);
-    
-    ConnectionRouterInterface *_make_router(const RouterLookahead* router_lookahead, bool is_flat, bool is_parallel) {
+
+    ConnectionRouterInterface *_make_router(const RouterLookahead* router_lookahead,
+                                            const t_router_opts& router_opts,
+                                            bool is_flat, bool is_parallel) {
         auto& device_ctx = g_vpr_ctx.device();
         auto& route_ctx = g_vpr_ctx.mutable_routing();
 
@@ -71,7 +73,11 @@ class SerialNetlistRouter : public NetlistRouter {
                 device_ctx.rr_rc_data,
                 device_ctx.rr_graph.rr_switch(),
                 route_ctx.rr_node_route_inf,
-                is_flat);
+                is_flat,
+                router_opts.multi_queue_num_threads,
+                router_opts.multi_queue_num_queues,
+                router_opts.multi_queue_direct_draining,
+                router_opts.thread_affinity);
             }
     }
     /* Context fields */

--- a/vpr/src/route/connection_router_interface.h
+++ b/vpr/src/route/connection_router_interface.h
@@ -23,6 +23,7 @@ struct t_conn_delay_budget {
 struct t_conn_cost_params {
     float criticality = 1.;
     float astar_fac = 1.2;
+    float astar_offset = 0.f;
     float post_target_prune_fac = 1.2f;
     float post_target_prune_offset = 0.f;
     float bend_cost = 1.;

--- a/vpr/src/route/multi_queue_priority_queue.cpp
+++ b/vpr/src/route/multi_queue_priority_queue.cpp
@@ -37,13 +37,7 @@ static inline pq_index_t cast_RRNodeId_to_pq_index_t(RRNodeId node) {
     return static_cast<pq_index_t>(std::size_t(node));
 }
 
-void MultiQueuePriorityQueue::add_to_heap(const pq_prio_t& prio, const RRNodeId& node, const RRNodeId& target_node) {
-    if (node == target_node) {
-#ifdef MQ_IO_ENABLE_CLEAR_FOR_POP
-        pq_->setMinPrioForPop(prio);
-#endif
-        return;
-    }
+void MultiQueuePriorityQueue::add_to_heap(const pq_prio_t& prio, const RRNodeId& node) {
     pq_->push({prio, cast_RRNodeId_to_pq_index_t(node)});
 }
 

--- a/vpr/src/route/multi_queue_priority_queue.cpp
+++ b/vpr/src/route/multi_queue_priority_queue.cpp
@@ -40,7 +40,7 @@ static inline pq_index_t cast_RRNodeId_to_pq_index_t(RRNodeId node) {
 void MultiQueuePriorityQueue::add_to_heap(const pq_prio_t& prio, const RRNodeId& node, const RRNodeId& target_node) {
     if (node == target_node) {
 #ifdef MQ_IO_ENABLE_CLEAR_FOR_POP
-        pq_.setMinPrio(new_total_cost);
+        pq_->setMinPrio(prio);
 #endif
         return;
     }

--- a/vpr/src/route/multi_queue_priority_queue.cpp
+++ b/vpr/src/route/multi_queue_priority_queue.cpp
@@ -40,7 +40,7 @@ static inline pq_index_t cast_RRNodeId_to_pq_index_t(RRNodeId node) {
 void MultiQueuePriorityQueue::add_to_heap(const pq_prio_t& prio, const RRNodeId& node, const RRNodeId& target_node) {
     if (node == target_node) {
 #ifdef MQ_IO_ENABLE_CLEAR_FOR_POP
-        pq_->setMinPrio(prio);
+        pq_->setMinPrioForPop(prio);
 #endif
         return;
     }

--- a/vpr/src/route/multi_queue_priority_queue.cpp
+++ b/vpr/src/route/multi_queue_priority_queue.cpp
@@ -20,7 +20,7 @@ void MultiQueuePriorityQueue::init_heap(const DeviceGrid& grid) {
 }
 
 bool MultiQueuePriorityQueue::try_pop(pq_prio_t &prio, RRNodeId &node) {
-    auto tmp = pq_->tryPop();
+    auto tmp = pq_->tryPopWithMinPrio();
     if (!tmp) {
         return false;
     } else {

--- a/vpr/src/route/multi_queue_priority_queue.cpp
+++ b/vpr/src/route/multi_queue_priority_queue.cpp
@@ -20,7 +20,7 @@ void MultiQueuePriorityQueue::init_heap(const DeviceGrid& grid) {
 }
 
 bool MultiQueuePriorityQueue::try_pop(pq_prio_t &prio, RRNodeId &node) {
-    auto tmp = pq_->tryPopWithMinPrio();
+    auto tmp = pq_->tryPop();
     if (!tmp) {
         return false;
     } else {
@@ -37,7 +37,13 @@ static inline pq_index_t cast_RRNodeId_to_pq_index_t(RRNodeId node) {
     return static_cast<pq_index_t>(std::size_t(node));
 }
 
-void MultiQueuePriorityQueue::add_to_heap(const pq_prio_t& prio, const RRNodeId& node) {
+void MultiQueuePriorityQueue::add_to_heap(const pq_prio_t& prio, const RRNodeId& node, const RRNodeId& target_node) {
+    if (node == target_node) {
+#ifdef MQ_IO_ENABLE_CLEAR_FOR_POP
+        pq_.setMinPrio(new_total_cost);
+#endif
+        return;
+    }
     pq_->push({prio, cast_RRNodeId_to_pq_index_t(node)});
 }
 

--- a/vpr/src/route/multi_queue_priority_queue.h
+++ b/vpr/src/route/multi_queue_priority_queue.h
@@ -1,7 +1,12 @@
 #ifndef _MULTI_QUEUE_PRIORITY_QUEUE_H
 #define _MULTI_QUEUE_PRIORITY_QUEUE_H
 
-// #define MQ_IO_ENABLE_CLEAR_FOR_POP
+// This is only used to enable the clearing code in the MQIO codebase. Whether
+// using queue draining optimization only depends on the VPR command-line option
+// `--multi_queue_direct_draining` setting during runtime. If the option is set
+// to `off`, the queue draining won't work since the `setMinPrioForPop` won't be
+// called leaving the `minPrioForPop` in MQIO object always as float maximum.
+#define MQ_IO_ENABLE_CLEAR_FOR_POP
 
 #include "heap_type.h"
 

--- a/vpr/src/route/multi_queue_priority_queue.h
+++ b/vpr/src/route/multi_queue_priority_queue.h
@@ -1,6 +1,8 @@
 #ifndef _MULTI_QUEUE_PRIORITY_QUEUE_H
 #define _MULTI_QUEUE_PRIORITY_QUEUE_H
 
+// #define MQ_IO_ENABLE_CLEAR_FOR_POP
+
 #include "heap_type.h"
 
 #include "MultiQueueIO.h"
@@ -26,7 +28,7 @@ class MultiQueuePriorityQueue {
 
     void init_heap(const DeviceGrid& grid);
     bool try_pop(pq_prio_t &prio, RRNodeId &node);
-    void add_to_heap(const pq_prio_t& prio, const RRNodeId& node);
+    void add_to_heap(const pq_prio_t& prio, const RRNodeId& node, const RRNodeId& target_node);
     void push_back(const pq_prio_t& prio, const RRNodeId& node);
     bool is_empty_heap() const;
     bool is_valid() const;
@@ -36,7 +38,6 @@ class MultiQueuePriorityQueue {
     inline uint64_t getNumPops() const { return pq_->getNumPops(); }
     inline uint64_t getHeapOccupancy() const { return pq_->getQueueOccupancy(); }
     inline void reset() { pq_->reset(); }
-    inline void setMinPrio(const pq_prio_t min_prio) { pq_->setMinPrioForPop(min_prio); }
 
   private:
     MQ_IO* pq_;

--- a/vpr/src/route/multi_queue_priority_queue.h
+++ b/vpr/src/route/multi_queue_priority_queue.h
@@ -28,7 +28,7 @@ class MultiQueuePriorityQueue {
 
     void init_heap(const DeviceGrid& grid);
     bool try_pop(pq_prio_t &prio, RRNodeId &node);
-    void add_to_heap(const pq_prio_t& prio, const RRNodeId& node, const RRNodeId& target_node);
+    void add_to_heap(const pq_prio_t& prio, const RRNodeId& node);
     void push_back(const pq_prio_t& prio, const RRNodeId& node);
     bool is_empty_heap() const;
     bool is_valid() const;
@@ -38,6 +38,9 @@ class MultiQueuePriorityQueue {
     inline uint64_t getNumPops() const { return pq_->getNumPops(); }
     inline uint64_t getHeapOccupancy() const { return pq_->getQueueOccupancy(); }
     inline void reset() { pq_->reset(); }
+#ifdef MQ_IO_ENABLE_CLEAR_FOR_POP
+    inline void setMinPrioForPop(const pq_prio_t& minPrio) { pq_->setMinPrioForPop(minPrio); }
+#endif
 
   private:
     MQ_IO* pq_;

--- a/vpr/src/route/multi_queue_priority_queue.h
+++ b/vpr/src/route/multi_queue_priority_queue.h
@@ -34,7 +34,9 @@ class MultiQueuePriorityQueue {
     void build_heap();
     inline uint64_t getNumPushes() const { return pq_->getNumPushes(); }
     inline uint64_t getNumPops() const { return pq_->getNumPops(); }
+    inline uint64_t getHeapOccupancy() const { return pq_->getQueueOccupancy(); }
     inline void reset() { pq_->reset(); }
+    inline void setMinPrio(const pq_prio_t min_prio) { pq_->setMinPrioForPop(min_prio); }
 
   private:
     MQ_IO* pq_;

--- a/vpr/src/route/parallel_connection_router.cpp
+++ b/vpr/src/route/parallel_connection_router.cpp
@@ -405,11 +405,6 @@ void ParallelConnectionRouter::timing_driven_route_connection_from_heap_thread_f
 
         // Should we explore the neighbors of this node?
 
-        if (inode == sink_node) {
-            heap_.setMinPrio(new_total_cost);
-            continue;
-        }
-
         if (should_not_explore_neighbors(inode, new_total_cost, rr_node_route_inf_[inode].backward_path_cost, sink_node, rr_node_route_inf_, cost_params)) {
             continue;
         }
@@ -634,7 +629,7 @@ void ParallelConnectionRouter::timing_driven_add_to_heap(const t_conn_cost_param
 
     releaseLock(to_node);
 
-    heap_.add_to_heap(next.total_cost, to_node);
+    heap_.add_to_heap(new_total_cost, to_node, target_node);
 
     // update_router_stats(router_stats_,
     //                     true,

--- a/vpr/src/route/parallel_connection_router.cpp
+++ b/vpr/src/route/parallel_connection_router.cpp
@@ -629,7 +629,13 @@ void ParallelConnectionRouter::timing_driven_add_to_heap(const t_conn_cost_param
 
     releaseLock(to_node);
 
-    heap_.add_to_heap(new_total_cost, to_node, target_node);
+    if (to_node == target_node) {
+#ifdef MQ_IO_ENABLE_CLEAR_FOR_POP
+        heap_.setMinPrioForPop(new_total_cost);
+#endif
+        return ;
+    }
+    heap_.add_to_heap(new_total_cost, to_node);
 
     // update_router_stats(router_stats_,
     //                     true,

--- a/vpr/src/route/parallel_connection_router.cpp
+++ b/vpr/src/route/parallel_connection_router.cpp
@@ -780,7 +780,7 @@ void ParallelConnectionRouter::evaluate_timing_driven_node_costs(node_t* to,
                                                               target_node,
                                                               cost_params,
                                                               to->R_upstream);
-    total_cost += to->backward_path_cost + cost_params.astar_fac * expected_cost;
+    total_cost += to->backward_path_cost + cost_params.astar_fac * std::max(0.f, expected_cost - cost_params.astar_offset);
 
     // if (rcv_path_manager.is_enabled() && to->path_data != nullptr) {
     //     to->path_data->backward_delay += cost_params.criticality * Tdel;
@@ -893,12 +893,8 @@ void ParallelConnectionRouter::add_route_tree_node_to_heap(
 
     // if (!rcv_path_manager.is_enabled()) {
         // tot_cost = backward_path_cost + cost_params.astar_fac * expected_cost;
-        float tot_cost = backward_path_cost
-                         + cost_params.astar_fac
-                               * router_lookahead_.get_expected_cost(inode,
-                                                                     target_node,
-                                                                     cost_params,
-                                                                     R_upstream);
+        float expected_cost = router_lookahead_.get_expected_cost(inode, target_node, cost_params, R_upstream);
+        float tot_cost = backward_path_cost + cost_params.astar_fac * std::max(0.f, expected_cost - cost_params.astar_offset);
         VTR_LOGV_DEBUG(router_debug_, "  Adding node %8d to heap from init route tree with cost %g (%s)\n",
                        inode,
                        tot_cost,

--- a/vpr/src/route/parallel_connection_router.cpp
+++ b/vpr/src/route/parallel_connection_router.cpp
@@ -392,7 +392,7 @@ void ParallelConnectionRouter::timing_driven_route_connection_from_heap_thread_f
     while (heap_.try_pop(new_total_cost, inode)) {
 #ifdef PROFILE_HEAP_OCCUPANCY
         if (thread_idx == 0) {
-            if (count % (1000 / mq_num_threads) == 0) {
+            if (count % 1000 == 0) {
                 heap_occ_profile_ << count << " " << heap_.getHeapOccupancy() << "\n";
             }
             count ++;
@@ -631,7 +631,9 @@ void ParallelConnectionRouter::timing_driven_add_to_heap(const t_conn_cost_param
 
     if (to_node == target_node) {
 #ifdef MQ_IO_ENABLE_CLEAR_FOR_POP
-        heap_.setMinPrioForPop(new_total_cost);
+        if (multi_queue_direct_draining_) {
+            heap_.setMinPrioForPop(new_total_cost);
+        }
 #endif
         return ;
     }

--- a/vpr/src/route/parallel_connection_router.h
+++ b/vpr/src/route/parallel_connection_router.h
@@ -11,7 +11,10 @@
 #include "router_stats.h"
 #include "spatial_route_tree_lookup.h"
 
+// #define PROFILE_HEAP_OCCUPANCY
+#ifdef PROFILE_HEAP_OCCUPANCY
 #include <fstream>
+#endif
 
 // For details on setting core affinity, please see `parse_core_affinity_list`.
 #define ENABLE_CORE_AFFINITY

--- a/vpr/src/route/parallel_connection_router.h
+++ b/vpr/src/route/parallel_connection_router.h
@@ -13,6 +13,7 @@
 
 #include <fstream>
 
+// For details on setting core affinity, please see `parse_core_affinity_list`.
 #define ENABLE_CORE_AFFINITY
 
 #define VPR_PARALLEL_CONNECTION_ROUTER_USE_MULTI_QUEUE
@@ -129,6 +130,10 @@ inline std::vector<std::string> get_tokens_split_by_delimiter(std::string str, c
     return tokens;
 }
 
+// To assign core affinity (i.e., pin threads to specific cores), please set the
+// environment variable `export VPR_CORE_AFFINITY=0-8` before running VPR.
+// Formats such as `0,1,2,3,4,5,6,7` and `0-7` and `0-3,4-7` and `0,1-2,3-6,7`
+// are all supported.
 inline std::vector<size_t> parse_core_affinity_list(std::string str) {
     std::vector<size_t> core_affinity_list;
     std::vector<std::string> lv1_tokens_split_by_comma = get_tokens_split_by_delimiter(str, ',');

--- a/vpr/src/route/route_net.tpp
+++ b/vpr/src/route/route_net.tpp
@@ -139,6 +139,7 @@ inline NetResultFlags route_net(ConnectionRouter *router,
     t_conn_delay_budget conn_delay_budget;
     t_conn_cost_params cost_params;
     cost_params.astar_fac = router_opts.astar_fac;
+    cost_params.astar_offset = router_opts.astar_offset;
     cost_params.post_target_prune_fac = router_opts.post_target_prune_fac;
     cost_params.post_target_prune_offset = router_opts.post_target_prune_offset;
     cost_params.bend_cost = router_opts.bend_cost;

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -96,6 +96,8 @@ bool RouterDelayProfiler::calculate_delay(RRNodeId source_node,
     cost_params.criticality = 1.;
     cost_params.astar_fac = router_opts.router_profiler_astar_fac;
     cost_params.astar_offset = router_opts.astar_offset;
+    cost_params.post_target_prune_fac = router_opts.post_target_prune_fac;
+    cost_params.post_target_prune_offset = router_opts.post_target_prune_offset;
     cost_params.bend_cost = router_opts.bend_cost;
 
     route_budgets budgeting_inf(net_list_, is_flat_);
@@ -166,6 +168,8 @@ vtr::vector<RRNodeId, float> calculate_all_path_delays_from_rr_node(RRNodeId src
     cost_params.criticality = 1.;
     cost_params.astar_fac = router_opts.astar_fac;
     cost_params.astar_offset = router_opts.astar_offset;
+    cost_params.post_target_prune_fac = router_opts.post_target_prune_fac;
+    cost_params.post_target_prune_offset = router_opts.post_target_prune_offset;
     cost_params.bend_cost = router_opts.bend_cost;
     /* This function is called during placement. Thus, the flat routing option should be disabled. */
     //TODO: Placement is run with is_flat=false. However, since is_flat is passed, det_routing_arch should

--- a/vpr/src/route/router_delay_profiling.cpp
+++ b/vpr/src/route/router_delay_profiling.cpp
@@ -95,6 +95,7 @@ bool RouterDelayProfiler::calculate_delay(RRNodeId source_node,
     t_conn_cost_params cost_params;
     cost_params.criticality = 1.;
     cost_params.astar_fac = router_opts.router_profiler_astar_fac;
+    cost_params.astar_offset = router_opts.astar_offset;
     cost_params.bend_cost = router_opts.bend_cost;
 
     route_budgets budgeting_inf(net_list_, is_flat_);
@@ -164,6 +165,7 @@ vtr::vector<RRNodeId, float> calculate_all_path_delays_from_rr_node(RRNodeId src
     t_conn_cost_params cost_params;
     cost_params.criticality = 1.;
     cost_params.astar_fac = router_opts.astar_fac;
+    cost_params.astar_offset = router_opts.astar_offset;
     cost_params.bend_cost = router_opts.bend_cost;
     /* This function is called during placement. Thus, the flat routing option should be disabled. */
     //TODO: Placement is run with is_flat=false. However, since is_flat is passed, det_routing_arch should

--- a/vpr/test/test_connection_router.cpp
+++ b/vpr/test/test_connection_router.cpp
@@ -41,6 +41,7 @@ static float do_one_route(RRNodeId source_node,
     t_conn_cost_params cost_params;
     cost_params.criticality = router_opts.max_criticality;
     cost_params.astar_fac = router_opts.astar_fac;
+    cost_params.astar_offset = router_opts.astar_offset;
     cost_params.bend_cost = router_opts.bend_cost;
 
     const Netlist<>& net_list = is_flat ? (const Netlist<>&)g_vpr_ctx.atom().nlist : (const Netlist<>&)g_vpr_ctx.clustering().clb_nlist;

--- a/vpr/test/test_connection_router.cpp
+++ b/vpr/test/test_connection_router.cpp
@@ -42,6 +42,8 @@ static float do_one_route(RRNodeId source_node,
     cost_params.criticality = router_opts.max_criticality;
     cost_params.astar_fac = router_opts.astar_fac;
     cost_params.astar_offset = router_opts.astar_offset;
+    cost_params.post_target_prune_fac = router_opts.post_target_prune_fac;
+    cost_params.post_target_prune_offset = router_opts.post_target_prune_offset;
     cost_params.bend_cost = router_opts.bend_cost;
 
     const Netlist<>& net_list = is_flat ? (const Netlist<>&)g_vpr_ctx.atom().nlist : (const Netlist<>&)g_vpr_ctx.clustering().clb_nlist;


### PR DESCRIPTION
1. Added core affinity support for parallel router.
2. Added a customized heap with indexing from one optimization and the ability to drain/clear the heap directly.
3. Added a heap occupancy profiling method to gain insight into the MQ heap occupancy and workload.

Note: To assign the core affinity (i.e., pin threads to specific cores), please set the environment variable `export VPR_CORE_AFFINITY=0,2-8`. Formats such as `0,1,2,3,4,5,6,7`, `0-7`, `0-3,4-7`, and `0,1-2,3-6,7` are all supported.

For multi-socket systems (i.e., with more than one NUMA node), please run `numactl` command for VPR execution. For example, `numactl --cpunodebind=<NUMA node> --membind=<NUMA node> vpr_wrapper.sh` (or simply `numactl --cpunodebind=0 --membind=0 bash` and run VPR or testing scripts inside the new bash).