### PR TITLE
[AP] Properly Inserted AP into VPR Flow

### DIFF
--- a/utils/fasm/src/main.cpp
+++ b/utils/fasm/src/main.cpp
@@ -72,11 +72,12 @@ int main(int argc, const char **argv) {
         /* Read options, architecture, and circuit netlist */
         vpr_init(argc, argv, &Options, &vpr_setup, &Arch);
 
-        vpr_setup.PackerOpts.doPacking    = STAGE_LOAD;
-        vpr_setup.PlacerOpts.doPlacement  = STAGE_LOAD;
-        vpr_setup.RouterOpts.doRouting    = STAGE_LOAD;
+        vpr_setup.PackerOpts.doPacking              = STAGE_LOAD;
+        vpr_setup.PlacerOpts.doPlacement            = STAGE_LOAD;
+        vpr_setup.PlacerOpts.doAnalyticalPlacement  = STAGE_SKIP;
+        vpr_setup.RouterOpts.doRouting              = STAGE_LOAD;
         vpr_setup.RouterOpts.read_rr_edge_metadata = true;
-        vpr_setup.AnalysisOpts.doAnalysis = STAGE_SKIP;
+        vpr_setup.AnalysisOpts.doAnalysis           = STAGE_SKIP;
 
         bool flow_succeeded = false;
         flow_succeeded = vpr_flow(vpr_setup, Arch);

--- a/utils/fasm/test/test_fasm.cpp
+++ b/utils/fasm/test/test_fasm.cpp
@@ -316,11 +316,12 @@ TEST_CASE("fasm_integration_test", "[fasm]") {
     vpr_init(sizeof(argv)/sizeof(argv[0]), argv,
               &options, &vpr_setup, &arch);
 
-    vpr_setup.PackerOpts.doPacking    = STAGE_LOAD;
-    vpr_setup.PlacerOpts.doPlacement  = STAGE_LOAD;
-    vpr_setup.RouterOpts.doRouting    = STAGE_LOAD;
+    vpr_setup.PackerOpts.doPacking              = STAGE_LOAD;
+    vpr_setup.PlacerOpts.doPlacement            = STAGE_LOAD;
+    vpr_setup.PlacerOpts.doAnalyticalPlacement  = STAGE_SKIP;
+    vpr_setup.RouterOpts.doRouting              = STAGE_LOAD;
     vpr_setup.RouterOpts.read_rr_edge_metadata = true;
-    vpr_setup.AnalysisOpts.doAnalysis = STAGE_SKIP;
+    vpr_setup.AnalysisOpts.doAnalysis           = STAGE_SKIP;
 
     bool flow_succeeded = vpr_flow(vpr_setup, arch);
     REQUIRE(flow_succeeded == true);

--- a/vpr/src/base/CheckSetup.cpp
+++ b/vpr/src/base/CheckSetup.cpp
@@ -60,6 +60,28 @@ void CheckSetup(const t_packer_opts& PackerOpts,
                         NUM_PL_MOVE_TYPES);
     }
 
+    // Rules for doing analytical placement.
+    if (PlacerOpts.doAnalyticalPlacement) {
+        // Make sure that the --place option was not set.
+        if (PlacerOpts.doPlacement) {
+            VPR_FATAL_ERROR(VPR_ERROR_OTHER,
+                            "Cannot perform both analytical and non-analytical placement.\n");
+        }
+        // Make sure that the --pack option was not set.
+        if (PackerOpts.doPacking) {
+            VPR_FATAL_ERROR(VPR_ERROR_OTHER,
+                            "Analytical placement should skip packing.\n");
+        }
+
+        // TODO: Should check that read_vpr_constraint_file is non-empty or
+        //       check within analytical placement that the floorplanning has
+        //       some fixed blocks somewhere. Maybe we can live without fixed
+        //       blocks.
+
+        // FIXME: Should we enforce that the size of the device is fixed? Or is
+        //        that defined in the constraints file?
+    }
+
     if (RouterOpts.doRouting) {
         if (!Timing.timing_analysis_enabled
             && (DEMAND_ONLY != RouterOpts.base_cost_type && DEMAND_ONLY_NORMALIZED_LENGTH != RouterOpts.base_cost_type)) {

--- a/vpr/src/base/SetupVPR.cpp
+++ b/vpr/src/base/SetupVPR.cpp
@@ -240,11 +240,13 @@ void SetupVPR(const t_options* Options,
     //do all
     if (!Options->do_packing
         && !Options->do_placement
+        && !Options->do_analytical_placement
         && !Options->do_routing
         && !Options->do_analysis) {
         //run all stages if none specified
         PackerOpts->doPacking = STAGE_DO;
         PlacerOpts->doPlacement = STAGE_DO;
+        PlacerOpts->doAnalyticalPlacement = STAGE_SKIP; // AP not default.
         RouterOpts->doRouting = STAGE_DO;
         AnalysisOpts->doAnalysis = STAGE_AUTO; //Deferred until implementation status known
     } else {
@@ -270,6 +272,12 @@ void SetupVPR(const t_options* Options,
         if (Options->do_placement) {
             PackerOpts->doPacking = STAGE_LOAD;
             PlacerOpts->doPlacement = STAGE_DO;
+        }
+
+        if (Options->do_analytical_placement) {
+            PackerOpts->doPacking = STAGE_SKIP;
+            PlacerOpts->doPlacement = STAGE_SKIP;
+            PlacerOpts->doAnalyticalPlacement = STAGE_DO;
         }
 
         if (Options->do_packing) {

--- a/vpr/src/base/ShowSetup.cpp
+++ b/vpr/src/base/ShowSetup.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <tuple>
 
 #include "vtr_assert.h"
 #include "vtr_log.h"
@@ -18,6 +19,7 @@ static void ShowPackerOpts(const t_packer_opts& PackerOpts);
 static void ShowNetlistOpts(const t_netlist_opts& NetlistOpts);
 static void ShowPlacerOpts(const t_placer_opts& PlacerOpts,
                            const t_annealing_sched& AnnealSched);
+static void ShowAnalyticalPlacerOpts(const t_placer_opts& PlacerOpts);
 static void ShowRouterOpts(const t_router_opts& RouterOpts);
 static void ShowAnalysisOpts(const t_analysis_opts& AnalysisOpts);
 static void ShowNocOpts(const t_noc_opts& NocOpts);
@@ -42,6 +44,7 @@ void ShowSetup(const t_vpr_setup& vpr_setup) {
 
     VTR_LOG("Packer: %s\n", (vpr_setup.PackerOpts.doPacking ? "ENABLED" : "DISABLED"));
     VTR_LOG("Placer: %s\n", (vpr_setup.PlacerOpts.doPlacement ? "ENABLED" : "DISABLED"));
+    VTR_LOG("Analytical Placer: %s\n", (vpr_setup.PlacerOpts.doAnalyticalPlacement ? "ENABLED" : "DISABLED"));
     VTR_LOG("Router: %s\n", (vpr_setup.RouterOpts.doRouting ? "ENABLED" : "DISABLED"));
     VTR_LOG("Analysis: %s\n", (vpr_setup.AnalysisOpts.doAnalysis ? "ENABLED" : "DISABLED"));
     VTR_LOG("\n");
@@ -55,6 +58,9 @@ void ShowSetup(const t_vpr_setup& vpr_setup) {
     }
     if (vpr_setup.PlacerOpts.doPlacement) {
         ShowPlacerOpts(vpr_setup.PlacerOpts, vpr_setup.AnnealSched);
+    }
+    if (vpr_setup.PlacerOpts.doAnalyticalPlacement) {
+        ShowAnalyticalPlacerOpts(vpr_setup.PlacerOpts);
     }
     if (vpr_setup.RouterOpts.doRouting) {
         ShowRouterOpts(vpr_setup.RouterOpts);
@@ -676,6 +682,11 @@ static void ShowPlacerOpts(const t_placer_opts& PlacerOpts,
         ShowAnnealSched(AnnealSched);
     }
     VTR_LOG("\n");
+}
+
+static void ShowAnalyticalPlacerOpts(const t_placer_opts& PlacerOpts) {
+    std::ignore = PlacerOpts;
+    // Currently nothing to show, but will happen eventually.
 }
 
 static void ShowNetlistOpts(const t_netlist_opts& NetlistOpts) {

--- a/vpr/src/base/read_options.cpp
+++ b/vpr/src/base/read_options.cpp
@@ -1315,6 +1315,11 @@ argparse::ArgumentParser create_arg_parser(const std::string& prog_name, t_optio
         .action(argparse::Action::STORE_TRUE)
         .default_value("off");
 
+    stage_grp.add_argument<bool, ParseOnOff>(args.do_analytical_placement, "--analytical_place")
+        .help("Run analytical placement")
+        .action(argparse::Action::STORE_TRUE)
+        .default_value("off");
+
     stage_grp.add_argument<bool, ParseOnOff>(args.do_routing, "--route")
         .help("Run routing")
         .action(argparse::Action::STORE_TRUE)

--- a/vpr/src/base/read_options.h
+++ b/vpr/src/base/read_options.h
@@ -45,6 +45,7 @@ struct t_options {
     /* Stage Options */
     argparse::ArgValue<bool> do_packing;
     argparse::ArgValue<bool> do_placement;
+    argparse::ArgValue<bool> do_analytical_placement;
     argparse::ArgValue<bool> do_routing;
     argparse::ArgValue<bool> do_analysis;
     argparse::ArgValue<bool> do_power;

--- a/vpr/src/base/vpr_api.cpp
+++ b/vpr/src/base/vpr_api.cpp
@@ -75,6 +75,7 @@
 #include "place_constraints.h"
 #include "place_util.h"
 #include "timing_fail_error.h"
+#include "analytical_placement_flow.h"
 
 #include "vpr_constraints_writer.h"
 
@@ -106,10 +107,6 @@
 #include "gateio.h"
 #include "serverupdate.h"
 #endif /* NO_SERVER */
-
-// FIXME: TESTING ONLY
-#include "analytical_initial_placer.h"
-#include "analytical_placement_flow.h"
 
 /* Local subroutines */
 static void free_complex_block_types();
@@ -410,9 +407,13 @@ bool vpr_flow(t_vpr_setup& vpr_setup, t_arch& arch) {
             return false; //Unimplementable
         }
     }
-    // Placed here for now; however, ideally this should come before pack and place since we do not want these to be performed.
-    // analytical_placement::initial_place();
-    run_analytical_placement_flow();
+
+    { //Analytical Place
+        if (vpr_setup.PlacerOpts.doAnalyticalPlacement == STAGE_DO) {
+            // TODO: Make this return a bool if the placement was successful or not.
+            run_analytical_placement_flow();
+        }
+    }
 
     bool is_flat = vpr_setup.RouterOpts.flat_routing;
     const Netlist<>& router_net_list = is_flat ? (const Netlist<>&)g_vpr_ctx.atom().nlist : (const Netlist<>&)g_vpr_ctx.clustering().clb_nlist;

--- a/vpr/src/base/vpr_types.h
+++ b/vpr/src/base/vpr_types.h
@@ -1204,6 +1204,10 @@ enum class e_move_type;
  *   @param doPlacement
  *              True if placement is supposed to be done in the CAD flow.
  *              False if otherwise.
+ *   @param doAnalyticalPlacement
+ *              True if analytical placement is supposed to be done in the CAD
+ *              flow.
+ *              False if otherwise.
  *   @param place_constraint_expand
  *              Integer value that specifies how far to expand the floorplan
  *              region when printing out floorplan constraints based on
@@ -1231,6 +1235,7 @@ struct t_placer_opts {
     int seed;
     float td_place_exp_last;
     e_stage_action doPlacement;
+    e_stage_action doAnalyticalPlacement;
     float rlim_escape_fraction;
     std::string move_stats_file;
     int placement_saves_per_temperature;


### PR DESCRIPTION
Instead of just riding off of the old place flow, created a custom argument for Analytical Placement (--analytical_place) which will only run the analytical placement flow (skipping over pack and place).

Since the device sizing requires the clustered netlist in order to size the grid, this adds a new requirement where the grid size must now be fixed in the architecture file using the FPGA Grid Layout.