### PR TITLE
[AP] Prepacker Rework

### DIFF
--- a/vpr/src/place/analytical_placement/analytical_placement_flow.cpp
+++ b/vpr/src/place/analytical_placement/analytical_placement_flow.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include "PartialPlacement.h"
 #include "ap_netlist.h"
+#include "ap_prepacker.h"
 #include "ap_utils.h"
 #include "AnalyticalSolver.h"
 #include "PlacementLegalizer.h"
@@ -21,9 +22,12 @@ void run_analytical_placement_flow() {
     const DeviceContext& device_ctx = g_vpr_ctx.device();
     const UserPlaceConstraints& constraints = g_vpr_ctx.floorplanning().constraints;
 
-    // Create the ap netlist from the atom netlist.
-    // FIXME: Resolve name.
-    APNetlist ap_netlist = read_atom_netlist(mutable_atom_ctx, constraints);
+    // Run the prepacker
+    APPrepacker prepacker(mutable_atom_ctx);
+
+    // Create the ap netlist from the atom netlist using the result from the
+    // prepacker.
+    APNetlist ap_netlist = read_atom_netlist(mutable_atom_ctx, prepacker, constraints);
     print_ap_netlist_stats(ap_netlist);
 
     // Set up the partial placement object

--- a/vpr/src/place/analytical_placement/ap_prepacker.cpp
+++ b/vpr/src/place/analytical_placement/ap_prepacker.cpp
@@ -1,0 +1,33 @@
+
+#include "ap_prepacker.h"
+#include <map>
+#include "prepack.h"
+#include "vpr_context.h"
+#include "vpr_types.h"
+#include "vtr_assert.h"
+#include "vtr_log.h"
+
+APPrepacker::APPrepacker(AtomContext& mutable_atom_ctx) {
+    VTR_LOG("Pre-Packing Atom Netlist\n");
+    // Run the prepacker.
+    list_of_pack_patterns = alloc_and_load_pack_patterns();
+    mutable_atom_ctx.list_of_pack_molecules.reset(alloc_and_load_pack_molecules(list_of_pack_patterns.data(), expected_lowest_cost_pb_gnode, list_of_pack_patterns.size()));
+}
+
+APPrepacker::~APPrepacker() {
+    // When the APPrepacker object is destroyed, clean up the list of pack patterns.
+    free_list_of_pack_patterns(list_of_pack_patterns);
+}
+
+t_pack_molecule* APPrepacker::get_atom_molecule(AtomBlockId atom_blk_id, const AtomContext& atom_ctx) const {
+    // The prepacking performed in the constructor populates the atom_molecules
+    // multimap within the atom context.
+    const std::multimap<AtomBlockId, t_pack_molecule*>& atom_molecules = atom_ctx.atom_molecules;
+    // Get the molecule associated with this atom.
+    // This assumes that the map only has one entry for each block. Have not hit
+    // a situation where this was not true.
+    VTR_ASSERT(atom_molecules.count(atom_blk_id) == 1 && "Only expect one molecule for a given block.");
+    auto mol_range = atom_molecules.equal_range(atom_blk_id);
+    return mol_range.first->second;
+}
+

--- a/vpr/src/place/analytical_placement/ap_prepacker.h
+++ b/vpr/src/place/analytical_placement/ap_prepacker.h
@@ -1,0 +1,41 @@
+
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+#include "atom_netlist_fwd.h"
+
+class AtomContext;
+class t_pack_molecule;
+class t_pack_patterns;
+class t_pb_graph_node;
+
+// The APPrepacker encapsulates the prepacker functionality and controls its
+// state (so we can avoid messing with global state).
+// This will prepack the atoms into molecules, where it will create "forced"
+// packs (LUT+FF) and carry chains.
+// See /pack/prepack.h and /pack/pack.cpp:try_pack
+// Two APPrepacker objects should NOT exist at the same time in a program (since
+// they maintain global state).
+// FIXME: This is an annoying limitation. Try to find a way to better enforce
+//        it.
+struct APPrepacker {
+    // This class is fiddling with the global state, and as such should not be
+    // copied or moved.
+    APPrepacker() = delete;
+    APPrepacker(const APPrepacker&) = delete;
+    APPrepacker& operator=(const APPrepacker&) = delete;
+    // Constructor of the prepacker. Performs pre-packing.
+    // Populates internal structures within the atom context.
+    APPrepacker(AtomContext& mutable_atom_ctx);
+    // Destructor. Frees the list of pack patterns. Does not delete the internal
+    // state of the atom context.
+    ~APPrepacker();
+    // Method to get the molecule an atom has be prepacked into.
+    t_pack_molecule* get_atom_molecule(AtomBlockId atom_blk_id, const AtomContext& atom_ctx) const;
+
+    std::vector<t_pack_patterns> list_of_pack_patterns;
+    // This is a map from the AtomBlock to its expected lowest cost primitive.
+    std::unordered_map<AtomBlockId, t_pb_graph_node*> expected_lowest_cost_pb_gnode;
+};
+

--- a/vpr/src/place/analytical_placement/read_atom_netlist.h
+++ b/vpr/src/place/analytical_placement/read_atom_netlist.h
@@ -2,8 +2,9 @@
 #pragma once
 
 class AtomContext;
+class APPrepacker;
 class UserPlaceConstraints;
 class APNetlist;
 
-APNetlist read_atom_netlist(AtomContext& mutable_atom_ctx, const UserPlaceConstraints& constraints);
+APNetlist read_atom_netlist(const AtomContext& atom_ctx, const APPrepacker& prepacker, const UserPlaceConstraints& constraints);
 


### PR DESCRIPTION
While working on the full legalizer, I realized that there are some data structures created during prepacking which may be useful for clustering during full legalization.

Encapsulated the prepacker into a class which handles the global variables and these data structures. This also logically removes the prepacker from reading the atom netlist which I think makes more sense.